### PR TITLE
Do not define strlcpy() if already defined as macro, as in OS X Yosemite

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,7 @@ AC_STRUCT_TIMEZONE
 AC_FUNC_FORK
 AC_CHECK_FUNCS([dup2 localtime_r memset setenv clearenv gethostname mkdir ftruncate strerror])
 AC_CHECK_FUNCS([strlcpy strcspn strdup strstr])
+AC_CHECK_DECLS([strlcpy])
 
 # ==== Output ===============================================================
 # Output

--- a/src/roll.c
+++ b/src/roll.c
@@ -64,7 +64,9 @@
 #include <getopt.h>
 #include <libgen.h>
 #include "log.h"
-#include "strlcpy.h"
+#if !defined(HAVE_STRLCPY) && !HAVE_DECL_STRLCPY
+    #include "strlcpy.h"
+#endif
 #include "config_parse.h"
 #include "environ.h"
 #include "packages.h"

--- a/src/strlcpy.c
+++ b/src/strlcpy.c
@@ -24,7 +24,7 @@
     #include <string.h>
 #endif
 
-#ifndef HAVE_STRLCPY
+#if !defined(HAVE_STRLCPY) && !HAVE_DECL_STRLCPY
 #include "strlcpy.h"
 
 /*
@@ -58,4 +58,4 @@ strlcpy(char *dst, const char *src, size_t siz)
         return(s - src - 1);    /* count does not include NUL */
 }
 
-#endif /* !HAVE_STRLCPY */
+#endif /* !defined(HAVE_STRLCPY) && !HAVE_DECL_STRLCPY */


### PR DESCRIPTION
As of the OS X Yosemite timeframe, OS X provides `strlcpy()` as a macro, not a function; but our check for `strlcpy()` only catches its existence if it is a function. Update autoconf input files to check for both a function or declaration, and update source code to skip local `strlcpy()` if either a function or macro are present.